### PR TITLE
Make Compiler-RT build for AArch64.

### DIFF
--- a/lib/builtins/CMakeLists.txt
+++ b/lib/builtins/CMakeLists.txt
@@ -242,10 +242,13 @@ set(arm_SOURCES
   arm/unordsf2vfp.S
   ${GENERIC_SOURCES})
 
+set(aarch64_SOURCES
+  ${GENERIC_SOURCES})
+
 add_custom_target(builtins)
 
 if (NOT WIN32)
-  foreach(arch x86_64 i386 arm)
+  foreach(arch x86_64 i386 arm aarch64)
     if(CAN_TARGET_${arch})
       add_compiler_rt_runtime(clang_rt.${arch} ${arch} STATIC
         SOURCES ${${arch}_SOURCES}

--- a/lib/builtins/aarch64/Makefile.mk
+++ b/lib/builtins/aarch64/Makefile.mk
@@ -1,4 +1,4 @@
-#===- lib/builtins/Makefile.mk -----------------------------*- Makefile -*--===#
+#===- lib/builtins/aarch64/Makefile.mk ---------------------*- Makefile -*--===#
 #
 #                     The LLVM Compiler Infrastructure
 #
@@ -8,15 +8,15 @@
 #===------------------------------------------------------------------------===#
 
 ModuleName := builtins
-SubDirs :=
+SubDirs := 
+OnlyArchs := aarch64
 
-# Add arch specific optimized implementations.
-SubDirs += i386 ppc x86_64 arm aarch64
-
-# Define the variables for this specific directory.
+AsmSources := $(foreach file,$(wildcard $(Dir)/*.S),$(notdir $(file)))
 Sources := $(foreach file,$(wildcard $(Dir)/*.c),$(notdir $(file)))
-ObjNames := $(Sources:%.c=%.o)
-Implementation := Generic
+ObjNames := $(Sources:%.c=%.o) $(AsmSources:%.S=%.o)
+Implementation := Optimized
 
 # FIXME: use automatic dependencies?
-Dependencies := $(wildcard $(Dir)/*.h)
+Dependencies := $(wildcard lib/*.h $(Dir)/*.h)
+
+CFLAGS.builtins := $(CFLAGS) -std=c99

--- a/lib/builtins/clear_cache.c
+++ b/lib/builtins/clear_cache.c
@@ -25,6 +25,10 @@
   #include <asm/unistd.h>
 #endif
 
+#if defined(__aarch64__) && !defined(__APPLE__)
+  #include <stddef.h>
+#endif
+
 /*
  * The compiler generates calls to __clear_cache() when creating 
  * trampoline functions on the stack for use with nested functions.


### PR DESCRIPTION
The revision currently used as submodule src/compiler-rt of rust does not build for AArch64. These small changes/additions fix this issue.
