### PR TITLE
iOS: building for arm64/aarch64

### DIFF
--- a/make/platform/triple.mk
+++ b/make/platform/triple.mk
@@ -54,7 +54,13 @@ ifeq ($(TargetTriple),arm-linux-androideabi)
                 sync_fetch_and_umin_8
 endif
 
+# Clear cache is builtin on aarch64-apple-ios
+# arm64 and aarch64 are synonims, but iOS targets usually use arm64 (history reasons)
+ifeq (aarch64-apple-ios,$(subst arm64,aarch64,$(TargetTriple)))
+CommonDisabledFunctions := clear_cache
+endif
+
 ArchEnabledFunctions := $(filter-out $(ArchDisabledFunctions),$(value ArchFunctions.$(Arch)))
+CommonEnabledFunctions := $(filter-out $(CommonDisabledFunctions),$(CommonFunctions_gcc))
 
-FUNCTIONS.builtins := $(CommonFunctions_gcc) $(ArchEnabledFunctions)
-
+FUNCTIONS.builtins := $(CommonEnabledFunctions) $(ArchEnabledFunctions)


### PR DESCRIPTION
clear_cache is builtin so it has to be skipped
