### PR TITLE
Remove UB from int-to-float conversion for INT_MIN.

### DIFF
--- a/lib/builtins/floatsidf.c
+++ b/lib/builtins/floatsidf.c
@@ -24,27 +24,26 @@ COMPILER_RT_ABI fp_t
 __floatsidf(int a) {
     
     const int aWidth = sizeof a * CHAR_BIT;
-    
+
     // Handle zero as a special case to protect clz
     if (a == 0)
         return fromRep(0);
     
     // All other cases begin by extracting the sign and absolute value of a
     rep_t sign = 0;
+    unsigned aAbs = (unsigned)a;
     if (a < 0) {
         sign = signBit;
-        a = -a;
+        aAbs = ~(unsigned)a + 1U;
     }
     
     // Exponent of (fp_t)a is the width of abs(a).
-    const int exponent = (aWidth - 1) - __builtin_clz(a);
+    const int exponent = (aWidth - 1) - __builtin_clz(aAbs);
     rep_t result;
     
-    // Shift a into the significand field and clear the implicit bit.  Extra
-    // cast to unsigned int is necessary to get the correct behavior for
-    // the input INT_MIN.
+    // Shift a into the significand field and clear the implicit bit.
     const int shift = significandBits - exponent;
-    result = (rep_t)(unsigned int)a << shift ^ implicitBit;
+    result = (rep_t)aAbs << shift ^ implicitBit;
     
     // Insert the exponent
     result += (rep_t)(exponent + exponentBias) << significandBits;

--- a/lib/builtins/floatsisf.c
+++ b/lib/builtins/floatsisf.c
@@ -24,30 +24,31 @@ COMPILER_RT_ABI fp_t
 __floatsisf(int a) {
     
     const int aWidth = sizeof a * CHAR_BIT;
-    
+
     // Handle zero as a special case to protect clz
     if (a == 0)
         return fromRep(0);
     
     // All other cases begin by extracting the sign and absolute value of a
     rep_t sign = 0;
+    unsigned aAbs = (unsigned)a;
     if (a < 0) {
         sign = signBit;
-        a = -a;
+        aAbs = ~(unsigned)a + 1U;
     }
     
     // Exponent of (fp_t)a is the width of abs(a).
-    const int exponent = (aWidth - 1) - __builtin_clz(a);
+    const int exponent = (aWidth - 1) - __builtin_clz(aAbs);
     rep_t result;
     
     // Shift a into the significand field, rounding if it is a right-shift
     if (exponent <= significandBits) {
         const int shift = significandBits - exponent;
-        result = (rep_t)a << shift ^ implicitBit;
+        result = (rep_t)aAbs << shift ^ implicitBit;
     } else {
         const int shift = exponent - significandBits;
-        result = (rep_t)a >> shift ^ implicitBit;
-        rep_t round = (rep_t)a << (typeWidth - shift);
+        result = (rep_t)aAbs >> shift ^ implicitBit;
+        rep_t round = (rep_t)aAbs << (typeWidth - shift);
         if (round > signBit) result++;
         if (round == signBit) result += result & 1;
     }


### PR DESCRIPTION
The fixed->float conversion intrinsics were carefully written to handle the case where the input is `INT_MIN`; e.g. avoiding sign extension via an intermediate cast to an unsigned int.

Unfortunately it wasn't quite careful enough; I am seeing evidence in https://github.com/rust-lang/rust/issues/36518 that one cannot rely on `-a` to behave in the same manner as `~(unsigned)a+1`, because it is simply undefined behavior.
- I found a useful discussion of that detail of `INT_MIN` here: http://stackoverflow.com/questions/37301078/is-negating-int-min-undefined-behaviour

Anyway, the fix I've chosen is simple enough: cast to `unsigned int` earlier in the computation and use `~a + 1` to do the negation.
