### PR TITLE
don't override arm calling convention

### DIFF
--- a/lib/builtins/int_lib.h
+++ b/lib/builtins/int_lib.h
@@ -32,7 +32,7 @@
 #if __ARM_EABI__
 # define ARM_EABI_FNALIAS(aeabi_name, name)         \
   void __aeabi_##aeabi_name() __attribute__((alias("__" #name)));
-# define COMPILER_RT_ABI __attribute__((pcs("aapcs")))
+# define COMPILER_RT_ABI
 #else
 # define ARM_EABI_FNALIAS(aeabi_name, name)
 # define COMPILER_RT_ABI


### PR DESCRIPTION
This should fix rust-lang/rust#37559.

With that line, the generated code transfers arguments / return value in `r0`, `r1` / `r0`.

Without that line, the generated code transfers the arguments / return value in `s0`, `r0` / `s0`.

I have no idea how this change will impact other builtins or targets other than `armv7-unknown-linux-gnueabihf`.

Tested with `arm-linux-gnueabihf-gcc` on Ubuntu.

cc @alexcrichton, @japaric, @nagisa