### PR TITLE
powi only: don't override arm calling convention

### DIFF
--- a/lib/builtins/int_lib.h
+++ b/lib/builtins/int_lib.h
@@ -32,7 +32,7 @@
 #if __ARM_EABI__
 # define ARM_EABI_FNALIAS(aeabi_name, name)         \
   void __aeabi_##aeabi_name() __attribute__((alias("__" #name)));
-# define COMPILER_RT_ABI
+# define COMPILER_RT_ABI __attribute__((pcs("aapcs")))
 #else
 # define ARM_EABI_FNALIAS(aeabi_name, name)
 # define COMPILER_RT_ABI

--- a/lib/builtins/powidf2.c
+++ b/lib/builtins/powidf2.c
@@ -16,7 +16,7 @@
 
 /* Returns: a ^ b */
 
-COMPILER_RT_ABI double
+double
 __powidf2(double a, si_int b)
 {
     const int recip = b < 0;

--- a/lib/builtins/powisf2.c
+++ b/lib/builtins/powisf2.c
@@ -16,7 +16,7 @@
 
 /* Returns: a ^ b */
 
-COMPILER_RT_ABI float
+float
 __powisf2(float a, si_int b)
 {
     const int recip = b < 0;


### PR DESCRIPTION
This should be a short term fix for rust-lang/rust#37630, while not regressing rust-lang/rust#37559.

cc @alexcrichton, @japaric, #25