### PR TITLE
Fix preprocessor directive for non-targeted platforms

### DIFF
--- a/lib/builtins/int_lib.h
+++ b/lib/builtins/int_lib.h
@@ -87,7 +87,7 @@
  * does not have dedicated bit counting instructions.
  */
 #if (defined(__sparc64__) || defined(__mips_n64) || defined(__mips_o64) || defined(__riscv__) \
-		|| (_MIPS_SIM == _ABI64) || (_MIPS_SIM == _ABIO64))
+		|| (defined(_MIPS_SIM) && ((_MIPS_SIM == _ABI64) || (_MIPS_SIM == _ABIO64))))
 si_int __clzsi2(si_int);
 si_int __ctzsi2(si_int);
 #define	__builtin_clz __clzsi2


### PR DESCRIPTION
The C preprocessor treats undefined identifiers in `#if` expressions
as `0` except for `true` and `false`, so the additional expression for
Linux-style MIPS ABIs actually turned to `0 == 0` for all other platforms
where `_MIPS_SIM` is not defined. Fix that by explicitly checking for
`_MIPS_SIM`'s presence.