### PR TITLE
Another workaround for LLVM bug 11663

### DIFF
--- a/lib/builtins/int_lib.h
+++ b/lib/builtins/int_lib.h
@@ -86,7 +86,7 @@
  * Presumably it's any version of GCC, and targeting an arch that
  * does not have dedicated bit counting instructions.
  */
-#if (defined(__sparc64__) || defined(__mips_n64) || defined(__mips_o64) || defined(__riscv__) \
+#if (defined(__sparc64__) || defined(__sparcv9) || defined(__mips_n64) || defined(__mips_o64) || defined(__riscv__) \
 		|| (defined(_MIPS_SIM) && ((_MIPS_SIM == _ABI64) || (_MIPS_SIM == _ABIO64))))
 si_int __clzsi2(si_int);
 si_int __ctzsi2(si_int);


### PR DESCRIPTION
Apply the same workaround from pull request #30 for __sparcv9 (the definition used on Solaris for sparc 64-bit) for LLVM Bug 11663 to prevent inifnite recursion in __c?zdi2().

This allows 64-bit sparc rust executables to work as expected on Solaris.