### PR TITLE
Use platform-independent preprocessor macros for sparc64

### DIFF
--- a/lib/builtins/int_lib.h
+++ b/lib/builtins/int_lib.h
@@ -89,7 +89,7 @@
  * Presumably it's any version of GCC, and targeting an arch that
  * does not have dedicated bit counting instructions.
  */
-#if (defined(__sparc64__) || defined(__sparcv9) || defined(__mips_n64) || defined(__mips_o64) || defined(__riscv__) \
+#if ((defined(__sparc__) || defined(__arch64__)) || defined(__mips_n64) || defined(__mips_o64) || defined(__riscv__) \
 		|| (defined(_MIPS_SIM) && ((_MIPS_SIM == _ABI64) || (_MIPS_SIM == _ABIO64))))
 si_int __clzsi2(si_int);
 si_int __ctzsi2(si_int);


### PR DESCRIPTION
sparc64 has different preprocessor definitons that can be used to detect the platform. There is ```__sparc64__```, ```__sparcv9``` and ```__sparc_v9__```. However, all of them are defined only on one of the three targets BSD, Solaris and Linux. A cross-platform way to detect sparc64 is testing whether both ```__sparc__``` and ```__arch64__``` is defined which is available on all three targets.

Solaris:

```
sysadmin@deimos:~$ uname -a
SunOS deimos 5.11 11.3 sun4v sparc sun4v
sysadmin@deimos:~$ echo | gcc -E -dM -m64 - |egrep '(arch|sparc)'
#define sparc 1
#define __sparc__ 1
#define __sparcv9 1
#define __sparc 1
#define __arch64__ 1
sysadmin@deimos:~$
```

Linux:

```
root@deb4g:~# uname -a
Linux deb4g 4.13.0-1-sparc64-smp #1 SMP Debian 4.13.4-2 (2017-10-15) sparc64 GNU/Linux
root@deb4g:~# echo | gcc -E -dM -m64 - |egrep '(arch|sparc)'
#define sparc 1
#define __sparc__ 1
#define __sparc 1
#define __sparc_v9__ 1
#define __arch64__ 1
root@deb4g:~#
```

I don't have a BSD at hand right now, but I know from the Firefox sources that BSD uses ```__sparc__``` and ```__arch64__``` as well. See https://bugzilla.mozilla.org/show_bug.cgi?id=953211#c5 for reference.

This addresses https://github.com/rust-lang/rust/issues/45487.