### PR TITLE
Fix logic error in sparc64 preprocessor macro

### DIFF
--- a/lib/builtins/int_lib.h
+++ b/lib/builtins/int_lib.h
@@ -89,7 +89,7 @@
  * Presumably it's any version of GCC, and targeting an arch that
  * does not have dedicated bit counting instructions.
  */
-#if ((defined(__sparc__) || defined(__arch64__)) || defined(__mips_n64) || defined(__mips_o64) || defined(__riscv__) \
+#if ((defined(__sparc__) && defined(__arch64__)) || defined(__mips_n64) || defined(__mips_o64) || defined(__riscv__) \
 		|| (defined(_MIPS_SIM) && ((_MIPS_SIM == _ABI64) || (_MIPS_SIM == _ABIO64))))
 si_int __clzsi2(si_int);
 si_int __ctzsi2(si_int);


### PR DESCRIPTION
This fixes a syntax error in the sparc64 preprocessor macro introduced by the previous commit, spotted by @jrtc27.