### PR TITLE
Re-add workaround for LLVM bug 11663

### DIFF
--- a/lib/builtins/int_lib.h
+++ b/lib/builtins/int_lib.h
@@ -77,6 +77,28 @@
 /* Include internal utility function declarations. */
 #include "int_util.h"
 
+/*
+ * Workaround for LLVM bug 11663.  Prevent endless recursion in
+ * __c?zdi2(), where calls to __builtin_c?z() are expanded to
+ * __c?zdi2() instead of __c?zsi2().
+ *
+ * Instead of placing this workaround in c?zdi2.c, put it in this
+ * global header to prevent other C files from making the detour
+ * through __c?zdi2() as well.
+ *
+ * This problem has been observed on FreeBSD for sparc64 and
+ * mips64 with GCC 4.2.1, and for riscv with GCC 5.2.0.
+ * Presumably it's any version of GCC, and targeting an arch that
+ * does not have dedicated bit counting instructions.
+ */
+#if ((defined(__sparc__) && defined(__arch64__)) || defined(__mips_n64) || defined(__mips_o64) || defined(__riscv__) \
+		|| (defined(_MIPS_SIM) && ((_MIPS_SIM == _ABI64) || (_MIPS_SIM == _ABIO64))))
+si_int __clzsi2(si_int);
+si_int __ctzsi2(si_int);
+#define	__builtin_clz __clzsi2
+#define	__builtin_ctz __ctzsi2
+#endif /* sparc64 || mips_n64 || mips_o64 || riscv */
+
 COMPILER_RT_ABI si_int __paritysi2(si_int a);
 COMPILER_RT_ABI si_int __paritydi2(di_int a);
 


### PR DESCRIPTION
This re-adds the workaround for LLVM bug 11663 which is unfortunately still present in LLVM 6.0 (see: https://bugs.llvm.org/show_bug.cgi?id=11663). It was lost when compiler-rt was updated to LLVM 6.0.